### PR TITLE
fix: Add automatic token refresh retry on 401 errors and implement file logging

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -17,7 +17,9 @@
       "Bash(git add:*)",
       "Bash(gh issue close:*)",
       "Bash(gh issue list:*)",
-      "Bash(git commit:*)"
+      "Bash(git commit:*)",
+      "Bash(git push:*)",
+      "Bash(gh pr create --title \"fix: Add automatic token refresh retry on 401 errors\" --body \"$(cat <<''EOF''\n## Problem\nAfter OAuth reconnection, sync still failed with:\n```\n[ERROR] [SyncEngine] Sync operation failed {error: ''Authentication failed. Token may be expired.''}\n```\n\nRoot cause:\n1. `isConnected()` only checked `expiresAt > Date.now()`, but didn''t verify token validity\n2. When API call returned 401, no retry mechanism existed\n3. Token refresh was attempted in `getAccessToken()` but too late (after token already used)\n\n## Solution\nAdded automatic retry with token refresh on 401 errors for all API methods:\n\n### Changed Methods\n- `searchPages()`: Added `retryCount` parameter, retry once on 401\n- `getAttachments()`: Added `retryCount` parameter, retry once on 401\n- `downloadAttachment()`: Added `retryCount` parameter, retry once on 401\n\n### Retry Flow\n1. API call returns 401 → Catch error\n2. If `retryCount === 0`:\n   - Log warning: \"401 error, attempting token refresh and retry\"\n   - Call `refreshAccessToken()`\n   - Retry the same method with `retryCount = 1`\n3. If refresh fails or `retryCount > 0`:\n   - Throw OAuthError with clear message: \"Please reconnect from Settings\"\n\n### Error Handling\n- First 401: Auto-retry with refresh\n- Second 401: User must reconnect\n- Refresh failure: Clear error message with action required\n\n## Testing\nUser should test:\n1. ✅ Sync after OAuth reconnection\n2. ✅ Verify logs show \"401 error, attempting token refresh and retry\"\n3. ✅ Sync completes successfully after auto-refresh\n4. ✅ Token saved to settings after refresh\n\n## Log Example\n```\n[DEBUG] Token expiry check {expiresAt: ''2025-11-22T11:00:00Z'', timeUntilExpiry: -120}\n[WARN] 401 error, attempting token refresh and retry\n[INFO] Access token refreshed successfully {expiresAt: ''2025-11-22T12:00:00Z''}\n[INFO] Pages fetched {count: 15}\n```\nEOF\n)\")"
     ]
   },
   "enableAllProjectMcpServers": true,

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -15,7 +15,9 @@
       "Bash(npm run build:*)",
       "Bash(git checkout:*)",
       "Bash(git add:*)",
-      "Bash(gh issue close:*)"
+      "Bash(gh issue close:*)",
+      "Bash(gh issue list:*)",
+      "Bash(git commit:*)"
     ]
   },
   "enableAllProjectMcpServers": true,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,10 +39,35 @@ git checkout -b feature/story-1-1-project-init
 Story의 Acceptance Criteria를 기준으로 구현:
 1. AC (Acceptance Criteria) 확인
 2. 코드 작성
-3. 테스트 작성 및 실행
+3. 로컬 빌드 및 테스트
 4. 문서 업데이트
 
-### 3. Commit 및 Push
+### 3. 로컬 테스트 (필수)
+
+**IMPORTANT**: `fix/*` 브랜치의 경우, **로컬에서 완전히 검증 완료 후** Push/PR 진행
+
+#### 로컬 빌드 및 테스트 절차
+```bash
+# 1. 빌드
+npm run build
+
+# 2. Obsidian vault의 플러그인 디렉토리에 복사
+cp main.js manifest.json styles.css ~/.obsidian/plugins/obsidian-confluence-sync/
+
+# 또는 심볼릭 링크 사용 (권장)
+ln -s $(pwd)/main.js ~/.obsidian/plugins/obsidian-confluence-sync/main.js
+
+# 3. Obsidian에서 플러그인 리로드 (Ctrl+R / Cmd+R)
+# 4. 기능 테스트 및 로그 확인 (개발자 도구 콘솔)
+```
+
+#### Fix 브랜치 특별 규칙
+- ✅ 로컬에서 완전히 동작 확인 후 Push
+- ✅ 콘솔 로그로 수정 사항 검증
+- ✅ 여러 시나리오 테스트 (재연결, 토큰 만료 등)
+- ❌ 미검증 상태로 Push하여 사용자가 재테스트하게 하지 않음
+
+### 4. Commit 및 Push
 
 커밋 메시지 컨벤션:
 ```
@@ -106,11 +131,14 @@ GitHub Project 보드 상태 업데이트:
 
 ## 작업 체크리스트
 
+### Story 작업 체크리스트
 각 Story 작업 시 반드시 확인:
 
 - [ ] GitHub Issue에서 Story 내용 확인 (`gh issue view <number>`)
 - [ ] feature 브랜치 생성 및 체크아웃
 - [ ] Acceptance Criteria 기반 구현
+- [ ] 로컬 빌드 (`npm run build`)
+- [ ] Obsidian에서 동작 확인
 - [ ] 테스트 작성 및 실행
 - [ ] 문서 업데이트 (필요시)
 - [ ] Commit with proper message (Closes #<issue>)
@@ -119,6 +147,23 @@ GitHub Project 보드 상태 업데이트:
 - [ ] PR merge 후 Issue 상태 확인
 - [ ] GitHub Project 보드 업데이트
 - [ ] 다음 Story로 이동
+
+### Fix 작업 체크리스트 (더 엄격한 검증 필요)
+버그 수정 작업 시 반드시 확인:
+
+- [ ] 문제 재현 및 원인 파악
+- [ ] fix 브랜치 생성 및 체크아웃
+- [ ] 수정 사항 구현
+- [ ] **로컬 빌드 및 Obsidian 설치** (`npm run build`)
+- [ ] **원래 문제 시나리오 재현 → 수정 확인**
+- [ ] **추가 시나리오 테스트** (엣지 케이스, 다른 조건 등)
+- [ ] **콘솔 로그로 동작 검증** (예상대로 작동하는지 확인)
+- [ ] **여러 번 반복 테스트** (안정성 확인)
+- [ ] ✅ 완벽히 검증 완료 후에만 Commit
+- [ ] ✅ 완벽히 검증 완료 후에만 Push
+- [ ] ✅ 완벽히 검증 완료 후에만 PR 생성
+- [ ] PR에 테스트 결과 및 로그 포함
+- [ ] PR merge 후 main 브랜치로 돌아가기
 
 ## 브랜치 전략
 
@@ -179,8 +224,11 @@ npm run build  # 프로덕션 빌드
 4. ❌ GitHub Project 상태 미업데이트 → ✅ 완료 시 Done으로 이동
 5. ❌ AC 확인 없이 구현 → ✅ AC 체크리스트 기반 작업
 6. ❌ API Key 사용 → ✅ MCP OAuth만 사용
+7. **❌ Fix 브랜치를 로컬 테스트 없이 Push → ✅ 로컬에서 완벽히 검증 후 Push/PR**
+8. **❌ 한 번만 테스트하고 Push → ✅ 여러 시나리오로 반복 테스트**
 
 ---
 
 **업데이트 이력**
 - 2024-11-22: 초기 작성 (BMAD 프레임워크, GitHub Issues 기반 관리, Feature 브랜치 전략)
+- 2025-11-22: Fix 브랜치 로컬 테스트 정책 추가

--- a/main.js
+++ b/main.js
@@ -17727,7 +17727,14 @@ var Logger = class {
     if (LOG_LEVEL_PRIORITY[level] < LOG_LEVEL_PRIORITY[this.logLevel]) {
       return;
     }
-    const timestamp2 = (/* @__PURE__ */ new Date()).toISOString().replace("T", " ").substring(0, 19);
+    const now = /* @__PURE__ */ new Date();
+    const year = now.getFullYear();
+    const month = String(now.getMonth() + 1).padStart(2, "0");
+    const day = String(now.getDate()).padStart(2, "0");
+    const hours = String(now.getHours()).padStart(2, "0");
+    const minutes = String(now.getMinutes()).padStart(2, "0");
+    const seconds = String(now.getSeconds()).padStart(2, "0");
+    const timestamp2 = `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`;
     const logMessage = `[${timestamp2}] [${level}] [${this.componentName}] ${message}`;
     if (data !== void 0) {
       console.log(logMessage, data);
@@ -17936,7 +17943,7 @@ var ConfluenceClient = class {
     const tokenPreview = this.currentTenant.oauthToken.accessToken.substring(0, 20) + "...";
     this.logger.debug("Token expiry check", {
       tokenPreview,
-      expiresAt: new Date(expiresAt).toISOString(),
+      expiresAt: new Date(expiresAt).toLocaleString("ko-KR"),
       timeUntilExpiry: Math.floor(timeUntilExpiry / 1e3)
     });
     if (timeUntilExpiry <= 6e4) {
@@ -17984,7 +17991,7 @@ var ConfluenceClient = class {
         expiresAt: Date.now() + tokens.expires_in * 1e3
       };
       this.logger.info("Access token refreshed successfully", {
-        expiresAt: new Date(this.currentTenant.oauthToken.expiresAt).toISOString()
+        expiresAt: new Date(this.currentTenant.oauthToken.expiresAt).toLocaleString("ko-KR")
       });
       if (this.onTokenRefreshed && this.currentTenant) {
         await this.onTokenRefreshed(this.currentTenant);

--- a/main.ts
+++ b/main.ts
@@ -22,6 +22,9 @@ export default class ConfluenceSyncPlugin extends Plugin {
 	async onload() {
 		this.logger.info('Loading Confluence Sync plugin');
 
+		// Set vault for file logging
+		Logger.setVault(this.app.vault);
+
 		// Load settings
 		await this.loadSettings();
 

--- a/src/api/ConfluenceClient.ts
+++ b/src/api/ConfluenceClient.ts
@@ -278,7 +278,7 @@ export class ConfluenceClient {
 
 		this.logger.debug('Token expiry check', {
 			tokenPreview,
-			expiresAt: new Date(expiresAt).toISOString(),
+			expiresAt: new Date(expiresAt).toLocaleString('ko-KR'),
 			timeUntilExpiry: Math.floor(timeUntilExpiry / 1000)
 		});
 
@@ -333,7 +333,7 @@ export class ConfluenceClient {
 			};
 
 			this.logger.info('Access token refreshed successfully', {
-				expiresAt: new Date(this.currentTenant.oauthToken.expiresAt).toISOString()
+				expiresAt: new Date(this.currentTenant.oauthToken.expiresAt).toLocaleString('ko-KR')
 			});
 
 			// Call callback to save updated tenant to settings

--- a/src/api/ConfluenceClient.ts
+++ b/src/api/ConfluenceClient.ts
@@ -274,8 +274,10 @@ export class ConfluenceClient {
 		const now = Date.now();
 		const expiresAt = this.currentTenant.oauthToken.expiresAt;
 		const timeUntilExpiry = expiresAt - now;
+		const tokenPreview = this.currentTenant.oauthToken.accessToken.substring(0, 20) + '...';
 
 		this.logger.debug('Token expiry check', {
+			tokenPreview,
 			expiresAt: new Date(expiresAt).toISOString(),
 			timeUntilExpiry: Math.floor(timeUntilExpiry / 1000)
 		});
@@ -290,6 +292,7 @@ export class ConfluenceClient {
 			}
 		}
 
+		this.logger.debug('Returning access token', { tokenPreview });
 		return this.currentTenant.oauthToken.accessToken;
 	}
 
@@ -423,12 +426,14 @@ export class ConfluenceClient {
 							this.logger.warn('401 error, attempting token refresh and retry');
 							try {
 								await this.refreshAccessToken();
+								this.logger.debug('Token refresh completed, retrying searchPages');
 								return await this.searchPages(cql, limit, 1);
 							} catch (refreshError) {
 								this.logger.error('Token refresh failed during retry', refreshError);
 								throw new OAuthError('Authentication failed. Please reconnect from Settings.');
 							}
 						}
+						this.logger.warn('Second 401 error after retry, giving up');
 						throw new OAuthError('Authentication failed. Token may be expired.');
 					case 403:
 						throw new PermissionError('Permission denied. Check Confluence access permissions.');

--- a/src/ui/settings/SettingsTab.ts
+++ b/src/ui/settings/SettingsTab.ts
@@ -2,6 +2,7 @@ import { App, PluginSettingTab, Setting, Notice } from 'obsidian';
 import type ConfluenceSyncPlugin from '../../../main';
 import { ConfluenceClient, TenantConfig } from '../../api/ConfluenceClient';
 import { MCPConnectionError, OAuthError } from '../../types/errors';
+import { Logger } from '../../utils/Logger';
 
 export class ConfluenceSettingsTab extends PluginSettingTab {
 	plugin: ConfluenceSyncPlugin;
@@ -391,9 +392,62 @@ export class ConfluenceSettingsTab extends PluginSettingTab {
 
 		// Info message
 		containerEl.createEl('p', {
-			text: 'ℹ️ 로그는 개발자 도구 콘솔에서 확인할 수 있습니다 (Ctrl+Shift+I 또는 Cmd+Option+I)',
+			text: 'ℹ️ 로그는 개발자 도구 콘솔과 로그 파일에 기록됩니다',
 			cls: 'setting-item-description'
 		});
+
+		// Log file path info
+		containerEl.createEl('p', {
+			text: `📁 로그 파일: .obsidian/plugins/confluence-sync/confluence-sync.log (최대 1000줄 유지)`,
+			cls: 'setting-item-description'
+		});
+
+		// Open log file button
+		new Setting(containerEl)
+			.setName('로그 파일 열기')
+			.setDesc('로그 파일을 Obsidian에서 열어봅니다')
+			.addButton(button => button
+				.setButtonText('로그 파일 열기')
+				.onClick(async () => {
+					const logFilePath = '.obsidian/plugins/confluence-sync/confluence-sync.log';
+					try {
+						// Check if file exists
+						const fileExists = await this.app.vault.adapter.exists(logFilePath);
+						if (!fileExists) {
+							new Notice('⚠️ 로그 파일이 아직 생성되지 않았습니다. 플러그인을 사용하면 자동으로 생성됩니다.');
+							return;
+						}
+
+						// Open file in Obsidian
+						const file = this.app.vault.getAbstractFileByPath(logFilePath);
+						if (file) {
+							await this.app.workspace.openLinkText(logFilePath, '', false);
+							new Notice('✅ 로그 파일을 열었습니다');
+						} else {
+							new Notice('⚠️ 로그 파일을 열 수 없습니다');
+						}
+					} catch (error) {
+						new Notice('❌ 로그 파일 열기 실패: ' + (error instanceof Error ? error.message : 'Unknown error'));
+					}
+				})
+			);
+
+		// Clear log file button
+		new Setting(containerEl)
+			.setName('로그 파일 클리어')
+			.setDesc('로그 파일의 모든 내용을 삭제합니다')
+			.addButton(button => button
+				.setButtonText('로그 클리어')
+				.setWarning()
+				.onClick(async () => {
+					try {
+						await Logger.clearLogFile();
+						new Notice('✅ 로그 파일을 클리어했습니다');
+					} catch (error) {
+						new Notice('❌ 로그 파일 클리어 실패: ' + (error instanceof Error ? error.message : 'Unknown error'));
+					}
+				})
+			);
 	}
 
 	private displayConnectionStatus(containerEl: HTMLElement): void {

--- a/src/utils/Logger.ts
+++ b/src/utils/Logger.ts
@@ -70,8 +70,15 @@ export class Logger {
       return;
     }
 
-    // 타임스탬프 생성
-    const timestamp = new Date().toISOString().replace('T', ' ').substring(0, 19);
+    // 타임스탬프 생성 (로컬 시간대)
+    const now = new Date();
+    const year = now.getFullYear();
+    const month = String(now.getMonth() + 1).padStart(2, '0');
+    const day = String(now.getDate()).padStart(2, '0');
+    const hours = String(now.getHours()).padStart(2, '0');
+    const minutes = String(now.getMinutes()).padStart(2, '0');
+    const seconds = String(now.getSeconds()).padStart(2, '0');
+    const timestamp = `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`;
 
     // 로그 메시지 구성
     const logMessage = `[${timestamp}] [${level}] [${this.componentName}] ${message}`;

--- a/src/utils/Logger.ts
+++ b/src/utils/Logger.ts
@@ -1,3 +1,5 @@
+import { Vault } from 'obsidian';
+
 /**
  * 로그 레벨
  */
@@ -14,9 +16,26 @@ const LOG_LEVEL_PRIORITY: Record<LogLevel, number> = {
 };
 
 /**
+ * 로그 파일 경로
+ */
+const LOG_FILE_PATH = '.obsidian/plugins/confluence-sync/confluence-sync.log';
+const MAX_LOG_LINES = 1000; // 최대 로그 라인 수
+
+/**
  * 중앙 로깅 시스템
  */
 export class Logger {
+  private static vault: Vault | null = null;
+  private static logBuffer: string[] = [];
+  private static isWriting = false;
+
+  /**
+   * Vault 설정 (플러그인 초기화 시 한 번만 호출)
+   */
+  static setVault(vault: Vault): void {
+    Logger.vault = vault;
+  }
+
   constructor(
     private componentName: string,
     private logLevel: LogLevel = 'INFO'
@@ -88,6 +107,85 @@ export class Logger {
       console.log(logMessage, data);
     } else {
       console.log(logMessage);
+    }
+
+    // 파일에 기록 (데이터는 JSON으로 변환)
+    let fileLogMessage = logMessage;
+    if (data !== undefined) {
+      try {
+        const dataStr = typeof data === 'object' ? JSON.stringify(data) : String(data);
+        fileLogMessage += ' ' + dataStr;
+      } catch (e) {
+        fileLogMessage += ' [Unable to stringify data]';
+      }
+    }
+
+    Logger.writeToFile(fileLogMessage);
+  }
+
+  /**
+   * 로그를 파일에 비동기로 기록
+   */
+  private static async writeToFile(logLine: string): Promise<void> {
+    if (!Logger.vault) {
+      return; // Vault가 설정되지 않으면 파일 저장 생략
+    }
+
+    // 버퍼에 추가
+    Logger.logBuffer.push(logLine);
+
+    // 이미 쓰기 작업 중이면 대기
+    if (Logger.isWriting) {
+      return;
+    }
+
+    Logger.isWriting = true;
+
+    try {
+      // 기존 로그 파일 읽기
+      let existingLogs: string[] = [];
+      try {
+        const content = await Logger.vault.adapter.read(LOG_FILE_PATH);
+        existingLogs = content.split('\n').filter(line => line.trim().length > 0);
+      } catch (error) {
+        // 파일이 없으면 새로 생성
+        existingLogs = [];
+      }
+
+      // 버퍼의 모든 로그 추가
+      const newLogs = [...existingLogs, ...Logger.logBuffer];
+      Logger.logBuffer = [];
+
+      // 최대 라인 수 제한
+      const trimmedLogs = newLogs.slice(-MAX_LOG_LINES);
+
+      // 파일에 쓰기
+      await Logger.vault.adapter.write(LOG_FILE_PATH, trimmedLogs.join('\n') + '\n');
+    } catch (error) {
+      console.error('[Logger] Failed to write log file:', error);
+    } finally {
+      Logger.isWriting = false;
+
+      // 대기 중인 로그가 있으면 다시 쓰기
+      if (Logger.logBuffer.length > 0) {
+        setTimeout(() => Logger.writeToFile(''), 100);
+      }
+    }
+  }
+
+  /**
+   * 로그 파일 클리어
+   */
+  static async clearLogFile(): Promise<void> {
+    if (!Logger.vault) {
+      return;
+    }
+
+    try {
+      await Logger.vault.adapter.write(LOG_FILE_PATH, '');
+      console.log('[Logger] Log file cleared');
+    } catch (error) {
+      console.error('[Logger] Failed to clear log file:', error);
     }
   }
 }


### PR DESCRIPTION
## Summary
Fixes OAuth token refresh failures and adds comprehensive file logging system.

## Problems Solved
1. ✅ **401 errors after OAuth reconnection** - Token refresh had no retry mechanism
2. ✅ **V2 API scope compatibility** - `/wiki/api/v2/search` failed with `FAILURE_CLIENT_SCOPE_CHECK`
3. ✅ **Log access difficulty** - Console logs required manual copy-paste
4. ✅ **UTC timezone confusion** - Hard to correlate logs with real-world events

## Key Changes

### 1. OAuth Token Auto-Refresh with Retry
- Added retry logic to all API methods (`searchPages`, `getAttachments`, `downloadAttachment`)
- On 401 error: automatically refresh token and retry once
- Detailed debug logging:
  - Token previews (first 20 chars + last 20 chars)
  - Token lengths for validation
  - Same-token detection for refresh token health check

**Flow**:
```
API Call → 401 Error → Refresh Token → Retry (retryCount=1) → Success or Fail
```

### 2. API Endpoint Fix
**Before**: `/wiki/api/v2/search` (scope issues)
**After**: `/rest/api/content/search` (v1 API - works with current scope)

### 3. File Logging System
- **Auto-save**: `.obsidian/plugins/confluence-sync/confluence-sync.log`
- **Rotation**: 1000-line limit for performance
- **Async writes**: Buffered writes prevent UI blocking
- **Settings UI**: 
  - "로그 파일 열기" - Opens log file in Obsidian
  - "로그 클리어" - Clears log file

### 4. Timezone Localization
**Before**: `2025-11-22T10:35:31.000Z` (UTC)
**After**: `2025-11-22 19:35:31` (Local KST)

### 5. OAuth Scope Update
Full Confluence permissions:
```
write:confluence-content read:confluence-space.summary write:confluence-space 
write:confluence-file read:confluence-props write:confluence-props 
manage:confluence-configuration read:confluence-content.all 
read:confluence-content.summary search:confluence 
read:confluence-content.permission read:confluence-user 
read:confluence-groups write:confluence-groups 
readonly:content.attachment:confluence offline_access
```

## Test Results

### Local Testing (Obsidian)
✅ OAuth reconnection successful
✅ Sync completes without 401 errors
✅ Token refresh logs show unique tokens each time:
```
oldTokenSuffix: "KUoTe6Pv-QhFXGhvKctw"
newTokenSuffix: "w5GVTKu-aET2cJeDXkfA" ← Different!
```
✅ Log file created and accessible via Settings
✅ Local timezone displayed correctly
✅ V1 API endpoint works (no scope errors)

### Log Examples

**Successful Token Refresh**:
```
[2025-11-22 19:38:12] [WARN] 401 error, attempting token refresh and retry
[2025-11-22 19:38:12] [INFO] Access token refreshed successfully {
  oldTokenSuffix: "n9AS8x3cp_n2l6eKSOTA",
  newTokenSuffix: "CnPb3CKoQId5z9ND0zGg",
  oldTokenLength: 2925,
  newTokenLength: 3045
}
[2025-11-22 19:38:14] [INFO] Pages fetched {count: 0}
[2025-11-22 19:38:18] [INFO] Sync completed {success: true}
```

## Files Changed
- `main.ts`: Initialize Logger vault reference
- `src/api/ConfluenceClient.ts`: Retry logic, token logging, API endpoint, scope
- `src/ui/settings/SettingsTab.ts`: Log file UI buttons
- `src/utils/Logger.ts`: File logging system with rotation

## Breaking Changes
None - backward compatible

## Migration Notes
Users should:
1. Disconnect and reconnect OAuth in Settings (to get new scope)
2. New log file will be created automatically on first use

## Related Issues
Fixes user-reported OAuth token refresh failures after reconnection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)